### PR TITLE
Add Term::ReadLine::Gnu to the skip list

### DIFF
--- a/lib/Dist/Zilla/Plugin/ReportVersions.pm
+++ b/lib/Dist/Zilla/Plugin/ReportVersions.pm
@@ -452,6 +452,7 @@ BEGIN {
       Moose::Role
       POE::Loop::Tk
       Template::Test
+      Term::ReadLine::Gnu
       Test::Kwalitee
       Test::Pod::Coverage
       Test::Portability::Files


### PR DESCRIPTION
...as this badness happens otherwise:

```
Failed test 'require Term::ReadLine::Gnu;'
at t/000-report-versions.t line 450.
    Tried to require 'Term::ReadLine::Gnu'.
    Error:  It is invalid to load Term::ReadLine::Gnu directly.  Please consult
the Term::ReadLine documentation for more information.
at /home/cweyl/perl5/perlbrew/perls/perl-5.14.2/lib/site_perl/5.14.2/x86_64-linux/Term/ReadLine/Gnu.pm line 69
```
